### PR TITLE
Track realtime listeners

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -10,8 +10,9 @@ export function activate(context: vscode.ExtensionContext) {
 	// auto trigger
 	const is_realtime = vscode.workspace.getConfiguration().get(`codepageValidator.RealTime`);
 	if(is_realtime) {
-		vscode.window.onDidChangeActiveTextEditor(processText); // switch tab
-		vscode.workspace.onDidChangeTextDocument(e => {	processText(vscode.window.activeTextEditor); }); // modify text
+		const activeEditorDisposable = vscode.window.onDidChangeActiveTextEditor(processText); // switch tab
+		const textDocumentDisposable = vscode.workspace.onDidChangeTextDocument(e => { processText(vscode.window.activeTextEditor); }); // modify text
+		context.subscriptions.push(activeEditorDisposable, textDocumentDisposable);
 	}
 
 }


### PR DESCRIPTION
## Summary
- track the active editor and text document listeners when realtime validation is enabled
- add the disposables to the extension context so they are cleaned up automatically

## Testing
- `npm test` *(fails: VS Code test runner is missing libatk-1.0.so.0 in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68cabfbb8d74832ba014f82b955014d8