### PR TITLE
Capture status bar item in activate

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -1,65 +1,76 @@
 import * as vscode from 'vscode';
 import * as iconv from 'iconv-lite';
 
-export function deactivate() { }
-export function activate(context: vscode.ExtensionContext) {
-	// manually trigger the function
-	const disposable = vscode.commands.registerTextEditorCommand(`extension.validateCodepage`, processText);
-	context.subscriptions.push(disposable);
+let statusBarItem: vscode.StatusBarItem | undefined;
+let deco: vscode.TextEditorDecorationType;
 
-	// auto trigger
-	const is_realtime = vscode.workspace.getConfiguration().get(`codepageValidator.RealTime`);
-	if(is_realtime) {
-		vscode.window.onDidChangeActiveTextEditor(processText); // switch tab
-		vscode.workspace.onDidChangeTextDocument(e => {	processText(vscode.window.activeTextEditor); }); // modify text
-	}
+export function activate(context: vscode.ExtensionContext) {
+        statusBarItem = vscode.window.createStatusBarItem();
+        context.subscriptions.push(statusBarItem);
+
+        // manually trigger the function
+        const disposable = vscode.commands.registerTextEditorCommand(`extension.validateCodepage`, processText);
+        context.subscriptions.push(disposable);
+
+        // auto trigger
+        const is_realtime = vscode.workspace.getConfiguration().get(`codepageValidator.RealTime`);
+        if(is_realtime) {
+                const activeEditorDisposable = vscode.window.onDidChangeActiveTextEditor(processText); // switch tab
+                const changeDocDisposable = vscode.workspace.onDidChangeTextDocument(() => { processText(vscode.window.activeTextEditor); }); // modify text
+                context.subscriptions.push(activeEditorDisposable, changeDocDisposable);
+        }
 
 }
 
-const bar = vscode.window.createStatusBarItem();
-
-let deco: vscode.TextEditorDecorationType;
+export function deactivate() {
+        if (statusBarItem) {
+                statusBarItem.hide();
+                statusBarItem = undefined;
+        }
+}
 
 function processText(textEditor: vscode.TextEditor | undefined) {
-	if(!textEditor) {
-		return;
-	}
-	// init decoration style
-	const fc: string = vscode.workspace.getConfiguration().get(`codepageValidator.Style.Foreground`) || `#0f0f`; // green
-	const bc: string = vscode.workspace.getConfiguration().get(`codepageValidator.Style.Background`) || `#cccf`; // grey
+        if(!textEditor) {
+                return;
+        }
+        // init decoration style
+        const fc: string = vscode.workspace.getConfiguration().get(`codepageValidator.Style.Foreground`) || `#0f0f`; // green
+        const bc: string = vscode.workspace.getConfiguration().get(`codepageValidator.Style.Background`) || `#cccf`; // grey
 
-	// clean decoration
-	if (deco) {
-		deco.dispose();
-	}
-	deco = vscode.window.createTextEditorDecorationType({ color: fc, backgroundColor: bc });
+        // clean decoration
+        if (deco) {
+                deco.dispose();
+        }
+        deco = vscode.window.createTextEditorDecorationType({ color: fc, backgroundColor: bc });
 
-	// generate list
-	const cp: string = vscode.workspace.getConfiguration().get(`codepageValidator.Charset`) || `utf8`;
-	// status bar
-	bar.text = `Checking Codepage: ` + cp;
-	bar.show();
-	// check characters one by one
-	let cp_list: vscode.Range[] = [];
-	
-	for (let i = 0; i < textEditor.document.lineCount; ++i) {
-		const line = textEditor.document.lineAt(i).text;
-		for (let j = 0; j < line.length; ++j) {
-			const uchar = line.charAt(j);
-			const loss = cpfilt(uchar, cp);
-			if (loss !== uchar) { // if the charset not compatible, they should be non-equal
-				cp_list.push(new vscode.Range(i, j, i, j + 1));
-			}
-		}
-	}
+        // generate list
+        const cp: string = vscode.workspace.getConfiguration().get(`codepageValidator.Charset`) || `utf8`;
+        // status bar
+        if (statusBarItem) {
+                statusBarItem.text = `Checking Codepage: ` + cp;
+                statusBarItem.show();
+        }
+        // check characters one by one
+        let cp_list: vscode.Range[] = [];
 
-	// apply list
-	textEditor.setDecorations(deco, cp_list);
+        for (let i = 0; i < textEditor.document.lineCount; ++i) {
+                const line = textEditor.document.lineAt(i).text;
+                for (let j = 0; j < line.length; ++j) {
+                        const uchar = line.charAt(j);
+                        const loss = cpfilt(uchar, cp);
+                        if (loss !== uchar) { // if the charset not compatible, they should be non-equal
+                                cp_list.push(new vscode.Range(i, j, i, j + 1));
+                        }
+                }
+        }
+
+        // apply list
+        textEditor.setDecorations(deco, cp_list);
 }
 
 // filter the string by specified codepage
 function cpfilt(str: string, filter: string): string {
-	const bin = iconv.encode(str, filter);
-	const ret = iconv.decode(bin, filter);
-	return ret;
+        const bin = iconv.encode(str, filter);
+        const ret = iconv.decode(bin, filter);
+        return ret;
 }


### PR DESCRIPTION
## Summary
- create the status bar item during activation and register it for disposal
- reuse the stored status bar entry during validation and hide it when the extension deactivates
- register real-time validation listeners for disposal with the extension context

## Testing
- npm run compile

------
https://chatgpt.com/codex/tasks/task_e_68cabfbdc65c832b998260bb3a4d80e9