### PR TITLE
Add option to automatically use document encoding

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Check if the text works in _given_ charset/codepage/encoding. If not, the plugin
 
 Steps:
 1. Open a text file.
-2. Set the charset you want to match.
+2. Use the document encoding automatically or set the charset you want to match manually.
 3. Non-compatible characters will be highlighted (for example, red).
 
 ![Demo GIF](images/demo.gif)
@@ -15,6 +15,7 @@ Steps:
 
 Target encoding:
 * `codepageValidator.Charset` → `Shift_JIS`
+* `codepageValidator.UseDocumentEncoding` → `true`
 
 Highlight text style:
 * `codepageValidator.Style.Foreground` → `red`
@@ -25,7 +26,6 @@ Validate when editing:
 
 ## Known Issues
 
-* [Upstream](https://github.com/microsoft/vscode/issues/824): It is _impossible_ to add an option auto picking the encoding.
 * The compatible version is not tested. This plugin may work or not work on vscode older than 1.41.0.
 
 ## Release Notes

--- a/package.json
+++ b/package.json
@@ -39,16 +39,21 @@
 						"default": "#f00f",
 						"description": "Format: #RGB, #RGBA, #RRGGBB, #RRGGBBAA"
 					},
-					"codepageValidator.Style.Background": {
-						"type": "string",
-						"default": "#fff0",
-						"description": "Format: #RGB, #RGBA, #RRGGBB, #RRGGBBAA"
-					},
-					"codepageValidator.RealTime": {
-						"type": "boolean",
-						"default": true,
-						"description": "Validate codepage when modifying text (Need reload)"
-					}
+                                        "codepageValidator.Style.Background": {
+                                                "type": "string",
+                                                "default": "#fff0",
+                                                "description": "Format: #RGB, #RGBA, #RRGGBB, #RRGGBBAA"
+                                        },
+                                        "codepageValidator.UseDocumentEncoding": {
+                                                "type": "boolean",
+                                                "default": true,
+                                                "description": "Automatically use TextDocument.encoding when available"
+                                        },
+                                        "codepageValidator.RealTime": {
+                                                "type": "boolean",
+                                                "default": true,
+                                                "description": "Validate codepage when modifying text (Need reload)"
+                                        }
 				}
 			}
 		]

--- a/src/main.ts
+++ b/src/main.ts
@@ -34,8 +34,9 @@ function processText(textEditor: vscode.TextEditor | undefined) {
                 return;
         }
         // init decoration style
-        const fc: string = vscode.workspace.getConfiguration().get(`codepageValidator.Style.Foreground`) || `#0f0f`; // green
-        const bc: string = vscode.workspace.getConfiguration().get(`codepageValidator.Style.Background`) || `#cccf`; // grey
+        const configuration = vscode.workspace.getConfiguration();
+        const fc: string = configuration.get(`codepageValidator.Style.Foreground`) || `#0f0f`; // green
+        const bc: string = configuration.get(`codepageValidator.Style.Background`) || `#cccf`; // grey
 
         // clean decoration
         if (deco) {
@@ -44,7 +45,14 @@ function processText(textEditor: vscode.TextEditor | undefined) {
         deco = vscode.window.createTextEditorDecorationType({ color: fc, backgroundColor: bc });
 
         // generate list
-        const cp: string = vscode.workspace.getConfiguration().get(`codepageValidator.Charset`) || `utf8`;
+        let cp: string = configuration.get(`codepageValidator.Charset`) || `utf8`;
+        const useDocumentEncoding = configuration.get<boolean>(`codepageValidator.UseDocumentEncoding`);
+        if (useDocumentEncoding) {
+                const documentEncoding = (textEditor.document as { encoding?: string }).encoding;
+                if (documentEncoding) {
+                        cp = documentEncoding;
+                }
+        }
         // status bar
         if (statusBarItem) {
                 statusBarItem.text = `Checking Codepage: ` + cp;


### PR DESCRIPTION
## Summary
- add a new configuration option that allows using the active document encoding when validating characters
- leverage TextDocument.encoding when available to determine the code page
- update documentation to describe the new automatic encoding support

## Testing
- npm run compile

------
https://chatgpt.com/codex/tasks/task_e_68cacb8461b0832b9c09ff02bde5a0e6